### PR TITLE
docs: 更新README中的项目链接地址

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 欢迎使用图片工具箱，免费在线压缩您的WebP、JPEG和PNG图片，纯本地运行无需上传至服务器
 
-[![image-tools](https://www.gausszhou.top/static/data/github/image-tools/1.png)](https://gausszhou.github.io/image-tools/)
+[![image-tools](https://www.gausszhou.top/static/data/github/image-tools/1.png)](https://gausstool.github.io/image-tools/)
 
 ## Features
 


### PR DESCRIPTION
将GitHub Pages链接从gausszhou.github.io更新为gausstool.github.io